### PR TITLE
Additions to the ArgoDSM version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,10 @@ SET_PROPERTY(CACHE BPMF_COMM PROPERTY STRINGS
   ARGO_COMM 
   NO_COMM)
 
+set(ARGO_RELEASE "NO_RELEASE" CACHE STRING "Release implementation used")
+SET_PROPERTY(CACHE ARGO_RELEASE PROPERTY STRINGS
+  NODE_WIDE_RELEASE
+  SELECTIVE_RELEASE)
 
 set(CMAKE_CXX_STANDARD 14)
 
@@ -70,6 +74,10 @@ message(STATUS "Version from git: ${BPMF_VERSION}")
 message(STATUS "num-latent: ${BPMF_NUMLATENT}")
 message(STATUS "comm: ${BPMF_COMM}")
 
+if(BPMF_COMM MATCHES ^ARGO)
+  message(STATUS "release implementation: ${ARGO_RELEASE}")
+endif()
+
 if (ONLY_VARIANCE)
   add_definitions(-DBPMF_NO_COVARIANCE)
 endif()
@@ -77,6 +85,7 @@ endif()
 add_definitions(-DBPMF_VERSION=\"${BPMF_VERSION}\")
 add_definitions(-DBPMF_NUMLATENT=${BPMF_NUMLATENT})
 add_definitions(-DBPMF_${BPMF_COMM})
+add_definitions(-DARGO_${ARGO_RELEASE})
 add_definitions(-DEIGEN_DONT_PARALLELIZE)
 
 if (ENABLE_REDUCE)

--- a/c++/bpmf_argo.h
+++ b/c++/bpmf_argo.h
@@ -83,10 +83,8 @@ void ARGO_Sys::process_queue()
 #if SSD_GRANULARITY == 0
         int q = queue.size();
         while (q--) {
-            m.lock();
             auto i = queue.front();
-            queue.pop_front();
-            m.unlock();
+            m.lock(); queue.pop_front(); m.unlock();
 
             auto offset = i * num_latent;
             auto size = num_latent;
@@ -99,7 +97,6 @@ void ARGO_Sys::process_queue()
         m.unlock();
 
         while (q) {
-            m.lock();
             auto i = queue.front();
             auto l = queue.begin();
             auto r = std::next(l);
@@ -107,8 +104,7 @@ void ARGO_Sys::process_queue()
             int c;
             for (c = 1; c < q; ++c, ++l, ++r)
                 if (!are_items_adjacent(*l, *r)) break;
-            pop_front(c);
-            m.unlock();
+            m.lock(); pop_front(c); m.unlock();
 
             auto offset = i * num_latent;
             auto size = c * num_latent;

--- a/c++/bpmf_argo.h
+++ b/c++/bpmf_argo.h
@@ -10,77 +10,110 @@
 
 struct ARGO_Sys : public Sys
 {
-	//-- c'tor
-	ARGO_Sys(std::string name, std::string fname, std::string probename) : Sys(name, fname, probename) {}
-	ARGO_Sys(std::string name, const SparseMatrixD &M, const SparseMatrixD &P) : Sys(name, M, P) {}
-	~ARGO_Sys();
+    //-- c'tor
+    ARGO_Sys(std::string name, std::string fname, std::string probename) : Sys(name, fname, probename) {}
+    ARGO_Sys(std::string name, const SparseMatrixD &M, const SparseMatrixD &P) : Sys(name, M, P) {}
+    ~ARGO_Sys();
 
-	virtual void alloc_and_init();
+    //-- virtuals
+    virtual void send_item(int);
+    virtual void sample(Sys &in);
+    virtual void alloc_and_init();
 
-	virtual void send_item(int);
-	virtual void sample(Sys &in);
+    //-- process_queue queue with protecting mutex
+    std::mutex m;
+    std::list<int> queue;
+    void process_queue();
+    void commit_index(int);
 };
 
 ARGO_Sys::~ARGO_Sys()
 {
-	argo::codelete_array(items_ptr);
+    argo::codelete_array(items_ptr);
 }
 
 void ARGO_Sys::alloc_and_init()
 {
-	items_ptr = argo::conew_array<double>(num_latent * num());
+    items_ptr = argo::conew_array<double>(num_latent * num());
 
-	init();
+    init();
 }
 
 void ARGO_Sys::send_item(int i)
 {
-#ifdef BPMF_ARGO_SELECTIVE_RELEASE
-	BPMF_COUNTER("send_item");
-	static std::mutex m;
+    commit_index(i);
+    process_queue();
+}
 
-	m.lock();
-	auto offset = i * num_latent;
-	auto size = num_latent;
-	argo::backend::selective_release(items_ptr+offset, size*sizeof(double));
-	m.unlock();
+void ARGO_Sys::commit_index(int i)
+{
+#ifdef BPMF_ARGO_SELECTIVE_RELEASE
+    m.lock(); queue.push_back(i); m.unlock();
 #endif
+}
+
+void ARGO_Sys::process_queue()
+{
+    int main_thread;
+    MPI_Is_thread_main(&main_thread);
+    if (!main_thread) return;
+
+    {
+        BPMF_COUNTER("process_queue");
+
+#if   defined(BPMF_ARGO_RELEASE)
+        argo::backend::release();
+#elif defined(BPMF_ARGO_SELECTIVE_RELEASE)
+        int q = queue.size();
+        while (q--) {
+            m.lock();
+            int i = queue.front();
+            queue.pop_front();
+            m.unlock();
+
+            auto offset = i * num_latent;
+            auto size = num_latent;
+            argo::backend::selective_release(items_ptr+offset, size*sizeof(double));
+        }
+#endif
+    }
 }
 
 void ARGO_Sys::sample(Sys &in)
 {
-	{
-		BPMF_COUNTER("compute");
-		Sys::sample(in);
-	}
-	{
-		BPMF_COUNTER("sync_sample");
-		Sys::sync();
-	}
+    { BPMF_COUNTER("compute"); Sys::sample(in); }
+
+    // send remaining
+    process_queue();
+
+    { BPMF_COUNTER("sync_sample"); Sys::sync(); }
+
+    // reduce small structs
+    reduce_sum_cov_norm();
 }
 
 void Sys::Init()
 {
-	// global address space size - 50GiB
-	argo::init(50*1024*1024*1024UL);
+    // global address space size - 50GiB
+    argo::init(50*1024*1024*1024UL);
 
-	Sys::procid = argo::node_id();
-	Sys::nprocs = argo::number_of_nodes();
+    Sys::procid = argo::node_id();
+    Sys::nprocs = argo::number_of_nodes();
 }
 
 void Sys::Finalize()
 {
-	argo::finalize();
+    argo::finalize();
 }
 
 void Sys::sync()
 {
-	argo::barrier();
+    argo::barrier();
 }
 
 void Sys::Abort(int err)
 {
-	MPI_Abort(MPI_COMM_WORLD, err);
+    MPI_Abort(MPI_COMM_WORLD, err);
 }
 
 void Sys::reduce_sum_cov_norm()

--- a/c++/bpmf_argo.h
+++ b/c++/bpmf_argo.h
@@ -41,13 +41,16 @@ void ARGO_Sys::alloc_and_init()
 
 void ARGO_Sys::send_item(int i)
 {
+#if defined(ARGO_NODE_WIDE_RELEASE) || \
+    defined(ARGO_SELECTIVE_RELEASE)
     commit_index(i);
     process_queue();
+#endif
 }
 
 void ARGO_Sys::commit_index(int i)
 {
-#ifdef BPMF_ARGO_SELECTIVE_RELEASE
+#ifdef ARGO_SELECTIVE_RELEASE
     m.lock(); queue.push_back(i); m.unlock();
 #endif
 }
@@ -61,9 +64,9 @@ void ARGO_Sys::process_queue()
     {
         BPMF_COUNTER("process_queue");
 
-#if   defined(BPMF_ARGO_RELEASE)
+#if   defined(ARGO_NODE_WIDE_RELEASE)
         argo::backend::release();
-#elif defined(BPMF_ARGO_SELECTIVE_RELEASE)
+#elif defined(ARGO_SELECTIVE_RELEASE)
         int q = queue.size();
         while (q--) {
             m.lock();

--- a/c++/bpmf_argo.h
+++ b/c++/bpmf_argo.h
@@ -8,10 +8,6 @@
 
 #define SYS ARGO_Sys
 
-//-- 0: fine-grained   ssd
-//-- 1: coarse-grained ssd
-#define SSD_GRANULARITY 1
-
 struct ARGO_Sys : public Sys
 {
     //-- c'tor
@@ -80,7 +76,7 @@ void ARGO_Sys::process_queue()
         argo::backend::release();
 #elif defined(ARGO_SELECTIVE_RELEASE)
 
-#if SSD_GRANULARITY == 0
+#ifdef FINE_GRAINED_SELECTIVE_RELEASE
         int q = queue.size();
         while (q--) {
             auto i = queue.front();


### PR DESCRIPTION
This PR:

* Adds missing `reduce_sum_cov_norm` call.
* Adds a node-wide self-downgrade implementation.
* Adds a course-grained selective-self-downgrade implementation.
* Adds an optimization to the selective-self-downgrade implementations.
* Adds CMAKE options to easily navigate between the implementations.

Available implementations:

* ARGO_RELEASE=NO_RELEASE (default)
Store/load operations with no explicit self-downgrade operations.
* ARGO_RELEASE=NODE_WIDE_RELEASE
Node-wide self-downgrade operations.
* ARGO_RELEASE=SELECTIVE_RELEASE
Fine-grained selective-self-downgrade (per item, needs to be set).
Coarse-grained selective-self-downgrade (group of items, default).