### PR TITLE
Swallowing the Semicolon

### DIFF
--- a/c++/bpmf_gaspi.h
+++ b/c++/bpmf_gaspi.h
@@ -29,7 +29,7 @@ do  { \
     Sys::cout() << "Error: " << #f << "[" << __FILE__ << ":" << __LINE__ << "]: " << r << std::endl;  \
     abort(); \
   } \
-} while (0);
+} while (0)
 
 
 static void gaspi_checked_wait(int k = 0)
@@ -60,7 +60,7 @@ do  { \
         abort(); \
       } \
   } while (r == GASPI_QUEUE_FULL); \
-} while (0);
+} while (0)
  
 static double* gaspi_malloc(gaspi_segment_id_t seg, size_t size) {
 	// Sys::cout() << "alloc id " << (int)seg << " with size " << (int)size << std::endl;


### PR DESCRIPTION
The point of using a `do … while` statement in macros is to swallow the
semicolon appearing at the end of the macro invocation.

`SUCCESS_OR_DIE` & `SUCCESS_OR_RETRY` currently expand to:
`SUCCESS_OR_DIE(...);` -> `do { ... } while (0);;`
`SUCCESS_OR_RETRY(...);` -> `do { ... } while (0);;`

The superfluous null statement (semicolon) can cause trouble in certain
cases. A related source to this PR can be found [here](https://gcc.gnu.org/onlinedocs/cpp/Swallowing-the-Semicolon.html#Swallowing-the-Semicolon).